### PR TITLE
Hide all internal symbols

### DIFF
--- a/hsluv.py
+++ b/hsluv.py
@@ -6,31 +6,31 @@ yourself, clone https://github.com/hsluv/hsluv and run:
 """
 
 from __future__ import division
-from functools import wraps, partial
-import math
+from functools import wraps as _wraps, partial as _partial
+import math as _math
 
 
 __version__ = '0.0.2'
 
-m = [[3.240969941904521, -1.537383177570093, -0.498610760293],
-     [-0.96924363628087, 1.87596750150772, 0.041555057407175],
-     [0.055630079696993, -0.20397695888897, 1.056971514242878]]
-minv = [[0.41239079926595, 0.35758433938387, 0.18048078840183],
-        [0.21263900587151, 0.71516867876775, 0.072192315360733],
-        [0.019330818715591, 0.11919477979462, 0.95053215224966]]
-refY = 1.0
-refU = 0.19783000664283
-refV = 0.46831999493879
-kappa = 903.2962962
-epsilon = 0.0088564516
-hex_chars = "0123456789abcdef"
+_m = [[3.240969941904521, -1.537383177570093, -0.498610760293],
+      [-0.96924363628087, 1.87596750150772, 0.041555057407175],
+      [0.055630079696993, -0.20397695888897, 1.056971514242878]]
+_min_v = [[0.41239079926595, 0.35758433938387, 0.18048078840183],
+          [0.21263900587151, 0.71516867876775, 0.072192315360733],
+          [0.019330818715591, 0.11919477979462, 0.95053215224966]]
+_ref_y = 1.0
+_ref_u = 0.19783000664283
+_ref_v = 0.46831999493879
+_kappa = 903.2962962
+_epsilon = 0.0088564516
+_hex_chars = "0123456789abcdef"
 
 
 def _normalize_output(conversion):
     # as in snapshot rev 4, the tolerance should be 1e-11
-    normalize = partial(round, ndigits=11-1)
+    normalize = _partial(round, ndigits=11-1)
 
-    @wraps(conversion)
+    @_wraps(conversion)
     def normalized(*args, **kwargs):
         color = conversion(*args, **kwargs)
         return [normalize(c) for c in color]
@@ -38,29 +38,29 @@ def _normalize_output(conversion):
 
 
 def _distance_line_from_origin(line):
-    v = math.pow(line['slope'], 2) + 1
-    return math.fabs(line['intercept']) / math.sqrt(v)
+    v = _math.pow(line['slope'], 2) + 1
+    return _math.fabs(line['intercept']) / _math.sqrt(v)
 
 
 def _length_of_ray_until_intersect(theta, line):
     return line['intercept']\
-         / (math.sin(theta) - line['slope'] * math.cos(theta))
+         / (_math.sin(theta) - line['slope'] * _math.cos(theta))
 
 
 def _get_bounds(l):
     result = []
-    sub1 = math.pow(l + 16, 3) / 1560896
-    if sub1 > epsilon:
+    sub1 = _math.pow(l + 16, 3) / 1560896
+    if sub1 > _epsilon:
         sub2 = sub1
     else:
-        sub2 = l / kappa
+        sub2 = l / _kappa
     _g = 0
     while _g < 3:
         c = _g
         _g = _g + 1
-        m1 = m[c][0]
-        m2 = m[c][1]
-        m3 = m[c][2]
+        m1 = _m[c][0]
+        m2 = _m[c][1]
+        m3 = _m[c][2]
         _g1 = 0
         while _g1 < 2:
             t = _g1
@@ -81,7 +81,7 @@ def _max_safe_chroma_for_l(l):
         i = _g
         _g = _g + 1
         length = _distance_line_from_origin(bounds[i])
-        if math.isnan(length):
+        if _math.isnan(length):
             _hx_min = length
         else:
             _hx_min = min(_hx_min, length)
@@ -89,7 +89,7 @@ def _max_safe_chroma_for_l(l):
 
 
 def _max_chroma_for_lh(l, h):
-    hrad = h / 360 * math.pi * 2
+    hrad = h / 360 * _math.pi * 2
     bounds = _get_bounds(l)
     _hx_min = 1.7976931348623157e+308
     _g = 0
@@ -98,7 +98,7 @@ def _max_chroma_for_lh(l, h):
         _g = (_g + 1)
         length = _length_of_ray_until_intersect(hrad, bound)
         if length >= 0:
-            if math.isnan(length):
+            if _math.isnan(length):
                 _hx_min = length
             else:
                 _hx_min = min(_hx_min, length)
@@ -120,44 +120,44 @@ def _from_linear(c):
     if c <= 0.0031308:
         return 12.92 * c
 
-    return 1.055 * math.pow(c, 0.416666666666666685) - 0.055
+    return 1.055 * _math.pow(c, 0.416666666666666685) - 0.055
 
 
 def _to_linear(c):
     if c > 0.04045:
-        return math.pow((c + 0.055) / 1.055, 2.4)
+        return _math.pow((c + 0.055) / 1.055, 2.4)
 
     return c / 12.92
 
 
 def xyz_to_rgb(_hx_tuple):
     return [
-        _from_linear(_dot_product(m[0], _hx_tuple)),
-        _from_linear(_dot_product(m[1], _hx_tuple)),
-        _from_linear(_dot_product(m[2], _hx_tuple))]
+        _from_linear(_dot_product(_m[0], _hx_tuple)),
+        _from_linear(_dot_product(_m[1], _hx_tuple)),
+        _from_linear(_dot_product(_m[2], _hx_tuple))]
 
 
 def rgb_to_xyz(_hx_tuple):
     rgbl = [_to_linear(_hx_tuple[0]),
             _to_linear(_hx_tuple[1]),
             _to_linear(_hx_tuple[2])]
-    return [_dot_product(minv[0], rgbl),
-            _dot_product(minv[1], rgbl),
-            _dot_product(minv[2], rgbl)]
+    return [_dot_product(_min_v[0], rgbl),
+            _dot_product(_min_v[1], rgbl),
+            _dot_product(_min_v[2], rgbl)]
 
 
 def _y_to_l(y):
-    if y <= epsilon:
-        return y / refY * kappa
+    if y <= _epsilon:
+        return y / _ref_y * _kappa
 
-    return 116 * math.pow(y / refY, 0.333333333333333315) - 16
+    return 116 * _math.pow(y / _ref_y, 0.333333333333333315) - 16
 
 
 def _l_to_y(l):
     if l <= 8:
-        return refY * l / kappa
+        return _ref_y * l / _kappa
 
-    return refY * math.pow((l + 16) / 116, 3)
+    return _ref_y * _math.pow((l + 16) / 116, 3)
 
 
 def xyz_to_luv(_hx_tuple):
@@ -176,8 +176,8 @@ def xyz_to_luv(_hx_tuple):
     l = _y_to_l(y)
     if l == 0:
         return [0, 0, 0]
-    u = 13 * l * (var_u - refU)
-    v = 13 * l * (var_v - refV)
+    u = 13 * l * (var_u - _ref_u)
+    v = 13 * l * (var_v - _ref_v)
     return [l, u, v]
 
 
@@ -187,8 +187,8 @@ def luv_to_xyz(_hx_tuple):
     v = float(_hx_tuple[2])
     if l == 0:
         return [0, 0, 0]
-    var_u = u / (13 * l) + refU
-    var_v = v / (13 * l) + refV
+    var_u = u / (13 * l) + _ref_u
+    var_v = v / (13 * l) + _ref_v
     y = _l_to_y(l)
     x = 0 - ((9 * y * var_u) / (((var_u - 4) * var_v) - var_u * var_v))
     z = (((9 * y) - (15 * var_v * y)) - (var_v * x)) / (3 * var_v)
@@ -203,11 +203,11 @@ def luv_to_lch(_hx_tuple):
     if _v < 0:
         c = float("nan")
     else:
-        c = math.sqrt(_v)
+        c = _math.sqrt(_v)
     if c < 0.00000001:
         h = 0
     else:
-        hrad = math.atan2(v, u)
+        hrad = _math.atan2(v, u)
         h = hrad * 180.0 / 3.1415926535897932
         if h < 0:
             h = 360 + h
@@ -218,9 +218,9 @@ def lch_to_luv(_hx_tuple):
     l = float(_hx_tuple[0])
     c = float(_hx_tuple[1])
     h = float(_hx_tuple[2])
-    hrad = h / 360.0 * 2 * math.pi
-    u = math.cos(hrad) * c
-    v = math.sin(hrad) * c
+    hrad = h / 360.0 * 2 * _math.pi
+    u = _math.cos(hrad) * c
+    v = _math.sin(hrad) * c
     return [l, u, v]
 
 
@@ -283,11 +283,11 @@ def rgb_to_hex(_hx_tuple):
         i = _g
         _g = _g + 1
         chan = float(_hx_tuple[i])
-        c = math.floor(chan * 255 + 0.5)
+        c = _math.floor(chan * 255 + 0.5)
         digit2 = int(c % 16)
         digit1 = int((c - digit2) / 16)
 
-        h += hex_chars[digit1] + hex_chars[digit2]
+        h += _hex_chars[digit1] + _hex_chars[digit2]
     return h
 
 
@@ -300,10 +300,10 @@ def hex_to_rgb(_hex):
         _g = _g + 1
         index = i * 2 + 1
         _hx_str = _hex[index]
-        digit1 = hex_chars.find(_hx_str)
+        digit1 = _hex_chars.find(_hx_str)
         index1 = i * 2 + 2
         str1 = _hex[index1]
-        digit2 = hex_chars.find(str1)
+        digit2 = _hex_chars.find(str1)
         n = digit1 * 16 + digit2
         ret.append(n / 255.0)
     return ret
@@ -352,3 +352,6 @@ def hex_to_hsluv(s):
 
 def hex_to_hpluv(s):
     return rgb_to_hpluv(hex_to_rgb(s))
+
+
+del division  # unexport


### PR DESCRIPTION
For your consideration

Previously, these symbols were exported by module `hsluv`:
`division`, `epsilon`, `hex_chars`, `kappa`, `m`, `math`, `minv`, `partial`, `refU`, `refV`, `refY`, `wraps`

`__all__` is not used because it only affects star imports.
With this merged, this is what you experience in IPython, as a result:

```
In [1]: import hsluv; [n for n in dir(hsluv) if not n.startswith('_')]
Out[1]:
['hex_to_hpluv',
 'hex_to_hsluv',
 'hex_to_rgb',
 'hpluv_to_hex',
 'hpluv_to_lch',
 'hpluv_to_rgb',
 'hsluv_to_hex',
 'hsluv_to_lch',
 'hsluv_to_rgb',
 'lch_to_hpluv',
 'lch_to_hsluv',
 'lch_to_luv',
 'lch_to_rgb',
 'luv_to_lch',
 'luv_to_xyz',
 'rgb_to_hex',
 'rgb_to_hpluv',
 'rgb_to_hsluv',
 'rgb_to_lch',
 'rgb_to_xyz',
 'xyz_to_luv',
 'xyz_to_rgb']
```