### PR TITLE
Make the code more pythonic

### DIFF
--- a/hsluv.py
+++ b/hsluv.py
@@ -303,3 +303,5 @@ def hex_to_hsluv(s):
 def hex_to_hpluv(s):
     return rgb_to_hpluv(hex_to_rgb(s))
 
+
+del division  # unexport

--- a/hsluv.py
+++ b/hsluv.py
@@ -245,9 +245,9 @@ def lch_to_hpluv(_hx_tuple):
 
 def rgb_to_hex(_hx_tuple):
     return '#{:02x}{:02x}{:02x}'.format(
-            _math.floor(_hx_tuple[0] * 255 + 0.5),
-            _math.floor(_hx_tuple[1] * 255 + 0.5),
-            _math.floor(_hx_tuple[2] * 255 + 0.5))
+            int(_math.floor(_hx_tuple[0] * 255 + 0.5)),
+            int(_math.floor(_hx_tuple[1] * 255 + 0.5)),
+            int(_math.floor(_hx_tuple[2] * 255 + 0.5)))
 
 
 def hex_to_rgb(_hex):


### PR DESCRIPTION
Calculate _ref_u and _ref_v from the CIE1931 D65 white point
Use division to calculate _kappa and _epsilon
Use ** operator rather than math.pow where possible
Use math.degrees and math.radians for angle unit conversions
In luv_to_lch, use math.hypot
In luv_to_lch, eliminate _v because it would never be negative
Greatly simplify these functions: _max_safe_chroma_for_l, _max_chroma_for_lh, _dot_product, rgb_to_hex, and hex_to_rgb


This is my first time doing a pull request.