### PR TITLE
Fix out-of-sync MANIFEST.in for Python 2 and 3 (fixes #28)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-include README.md
-include LICENSE
+include LICENSE.txt


### PR DESCRIPTION
Fixes #28

For Python 3, we could just drop the file and be good.
For Python 2 however, `LICENSE.txt` is not on the magic inclusion list and still needs to be added.

@boronine are you on board with dropping support for [end-of-life Python <3.6](https://endoflife.date/python) from hsluv?

CC @dvzrv