### PR TITLE
Improve discoverability of repository by add metadata to distibuable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,9 @@ setup(
         'setuptools>=38.6.0',  # for long_description_content_type
     ],
     py_modules=["hsluv"],
-    test_suite="tests.test_hsluv"
+    test_suite="tests.test_hsluv",
+    project_urls={
+        "Bug Tracker": "https://github.com/hsluv/hsluv-python/issues",
+        "Source Code": "https://github.com/hsluv/hsluv-python",
+    }
 )


### PR DESCRIPTION
Add links that will be rendered on hsluv page on pypi. 

view of links for hsluv on pypi: 
![Zrzut ekranu z 2022-06-14 09-13-46](https://user-images.githubusercontent.com/3826210/173516489-566a6c89-1cdd-4994-a960-554f625e2c80.png)

view of links for numpy:
![Zrzut ekranu z 2022-06-14 09-13-57](https://user-images.githubusercontent.com/3826210/173516495-f0a42c8b-cc8b-440a-9b9d-3f232ffc3346.png)

(numpy uses also `download_url` parameter of setup.py)

I create this PR because for me it was simpler to find @boronine email (from the project webpage) than find this repository. 


 