### PR TITLE
Fix CI (by replacing call `python setup.py test` with pytest)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,9 @@ jobs:
         run: |-
           set -x
           pip install -U setuptools  # for Python >=3.12
+          pip install pytest
           python setup.py sdist
           cd dist/
           tar xf hsluv-*.tar.gz
           cd hsluv-*/
-          python setup.py test
+          pytest -v tests/


### PR DESCRIPTION
.. because Setuptools >=72 stopped providing that command:

https://setuptools.pypa.io/en/stable/history.html#v72-0-0

CC https://github.com/hartwork/resolve-march-native/pull/170